### PR TITLE
Added option to disable MetaMagik info on card

### DIFF
--- a/Controller/SettingsController.php
+++ b/Controller/SettingsController.php
@@ -59,6 +59,15 @@ class SettingsController extends BaseController
             $options = array_merge($options, $plugin_groupassign);
         }
 
+        // Check if MetaMagik PlugIn is available, if so show option to deaktivate icon and count display
+        $pluginFMetaMagik = PLUGINS_DIR . DIRECTORY_SEPARATOR . basename('MetaMagik');
+        if (file_exists($pluginFMetaMagik)) {
+            $plugin_metamagik = [
+                t('Card: hide metamagik infos') => 'boardcustomizer_metamagik_hide_icon_count'
+            ];
+            $options = array_merge($options, $plugin_metamagik);
+        }        
+
         $this->response->html($this->helper->layout->user('boardcustomizer:user/settings', [
             'title'   => t('My display settings'),
             'user'    => $user,

--- a/Locale/de_DE/translations.php
+++ b/Locale/de_DE/translations.php
@@ -18,4 +18,5 @@ return array(
     'Card: hide score' => 'Karte: Komplexität ausblenden',
     'Card: hide time estimated' => 'Karte: geschätzte Zeit ausblenden',
     'Card: hide task date' => 'Karte: Datum ausblenden',
+    'Card: hide metamagik infos' => 'Karte: MetaMagik Infos ausblenden'
 );

--- a/Locale/fr_FR/translations.php
+++ b/Locale/fr_FR/translations.php
@@ -18,4 +18,5 @@ return array(
     'Card: hide score' => 'Carte : Masquer la complexité',
     'Card: hide time estimated' => 'Carte : Masquer le temps estimé',
     'Card: hide task date' => 'Carte : Masquer la date d\'échance',
+    'Card: hide metamagik infos' => 'Carte : Cacher les infos sur la MetaMagik',
 );

--- a/Template/layout/head.php
+++ b/Template/layout/head.php
@@ -89,6 +89,16 @@ if ($this->user->userMetadataModel->exists($this->user->getid(), "boardcustomize
     </style>
 <?php
 }
+if ($this->user->userMetadataModel->exists($this->user->getid(), "boardcustomizer_metamagik_hide_icon_count")) {
+    /* hide MetaMagiK icon and counter */
+    ?>
+    <style>
+        .metamagik-icon-count {
+            display: none;
+        }
+    </style>
+<?php
+}
 if ($this->user->userMetadataModel->exists($this->user->getid(), "boardcustomizer_whitebackground")) {
     /* task white background */
     ?>


### PR DESCRIPTION
I've added an option  to disable the MetaMagik infos on a task

![grafik](https://user-images.githubusercontent.com/82320201/211606333-8640824f-4c22-42a1-88fb-9710090e414f.png)

The missing class name for the output snippet has already been pulled by @creecros into MetaMagik but is not yet available as a release. 

https://github.com/creecros/MetaMagik/commits?author=JustFxDev

I've also added DE and FR texts. Someone with more french language experience should doublecheck.

![grafik](https://user-images.githubusercontent.com/82320201/211607223-3273b840-9c3c-4e77-9c50-e61a3b08f1d6.png)

Cheers, Fx
